### PR TITLE
Update 12-12-2024

### DIFF
--- a/SNDINFO.txt
+++ b/SNDINFO.txt
@@ -141,7 +141,7 @@ $rolloff artifact/bomb/beacon		linear	56 300
 artifact/bomb/beacon					flchtbcn
 timebomb/tic								tictoc
 
-artifact/banish								banpck
+artifact/banish								banpick
 artifact/banish/ann						annban
 artifact/banish/use						banuse
 $rolloff artifact/banish/beacon		linear	56 300

--- a/decorate/Pickups/Artifacts/ArtiTorch_Toby.dec
+++ b/decorate/Pickups/Artifacts/ArtiTorch_Toby.dec
@@ -12,7 +12,7 @@ ACTOR ArtiTorch_Toby : CustomInventory replaces ArtiTorch
 	{
 	Spawn:
 		TRCH A 3 Bright A_SpawnItemEx("TorchPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		TRCH BCABCABCABCABCABCABCABC 3 Bright
+		TRCH BCABCABCABC 3 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("TorchGiver", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/BanDevice_Toby.dec
+++ b/decorate/Pickups/Artifacts/BanDevice_Toby.dec
@@ -12,8 +12,8 @@ ACTOR ArtiTeleportOther_Toby : CustomInventory 10040
 	States
 	{
 	Spawn:
-		TELO A 4 Bright A_SpawnItemEx("BanishPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		TELO BCDABCDABCD 4 Bright
+		TELO A 2 Bright A_SpawnItemEx("BanishPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		TELO BCDABCDABCDABCDABCD 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("ArtiTeleportOther_2", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/BlastRadius_Toby.dec
+++ b/decorate/Pickups/Artifacts/BlastRadius_Toby.dec
@@ -11,8 +11,8 @@ ACTOR ArtiBlastRadius_Toby : CustomInventory 10110
 	States
 	{
 	Spawn:
-		BLST A 3 Bright A_SpawnItemEx("BlastPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		BLST BCDEFGHABCDEFGH 3 Bright
+		BLST A 5 Bright A_SpawnItemEx("BlastPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		BLST BCDEFGH 5 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("ArtiBlastRadius_2", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/ChaosDevice_Toby.dec
+++ b/decorate/Pickups/Artifacts/ChaosDevice_Toby.dec
@@ -10,8 +10,8 @@ ACTOR ArtiTeleport_Toby : CustomInventory 36
 	States
 	{
 	Spawn:
-		ATLP A 4 Bright A_SpawnItemEx("ChaosPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		ATLP BCBABCBABCBABCB 4 Bright
+		ATLP A 2 Bright A_SpawnItemEx("ChaosPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		ATLP BCBABCBABCBABCBABCB 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("ArtiTeleport_2", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/Defender_Toby.dec
+++ b/decorate/Pickups/Artifacts/Defender_Toby.dec
@@ -11,8 +11,8 @@ ACTOR ArtiInvulnerability2_Toby : CustomInventory replaces ArtiInvulnerability2
 	States
 	{
 	Spawn:
-		DEFN A 3 Bright A_SpawnItemEx("DefenderPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		DEFN BCDABCDABCDABCDABCD 3 Bright
+		DEFN A 2 Bright A_SpawnItemEx("DefenderPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		DEFN BCDABCDABCDABCDABCD 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("ArtiInvulnerability2_Giver", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/SpeedBoots_Toby.dec
+++ b/decorate/Pickups/Artifacts/SpeedBoots_Toby.dec
@@ -10,8 +10,8 @@ ACTOR SpeedBoots_Toby : CustomInventory 8002
 	States
 	{
 	Spawn:
-		SPED A 3 Bright A_SpawnItemEx("BootsPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		SPED BCDEFGHABCDEFGH 3 Bright
+		SPED A 4 Bright A_SpawnItemEx("BootsPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		SPED BCDEFGH 4 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("ArtiSpeedBoots_Giver", 25, "NoPickup")

--- a/decorate/Pickups/Artifacts/WingsOfWrath_Toby.dec
+++ b/decorate/Pickups/Artifacts/WingsOfWrath_Toby.dec
@@ -11,8 +11,8 @@ ACTOR ArtiFly_Toby : CustomInventory replaces ArtiFly
 	States
 	{
 	Spawn:
-		SOAR A 3 Bright A_SpawnItemEx("WingsPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		SOAR BCBABCBABCBABCBABCBABCB 3 Bright
+		SOAR A 2 Bright A_SpawnItemEx("WingsPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		SOAR BCBABCBABCBABCBABC 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("WingsGiver", 25, "NoPickup")


### PR DESCRIPTION
Modified the frequency of the item beacon sounds. As per stormdragon's recommendations, beacon frequency should be every 1 - 1.25 seconds. Some needed to be 1.5 seconds but everything should be balanced.